### PR TITLE
chore: Using fastapi.responses.ORJSONResponse as default response class.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,21 +1,10 @@
-from typing import Any
-
-import orjson
 from fastapi import FastAPI
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import ORJSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
 from app.api.api_v1.api import api_router
 from app.core.config import settings
-
-
-class ORJSONResponse(JSONResponse):
-    media_type = "application/json"
-
-    def render(self, content: Any) -> bytes:
-        return orjson.dumps(content)
-
 
 app = FastAPI(
     title=settings.PROJECT_NAME,


### PR DESCRIPTION
chore: Using fastapi.responses.ORJSONResponse as default response class in main.py.