### PR TITLE
feat: Improved the get_multi() call to return a Tuple of query, count.

### DIFF
--- a/app/api/api_v1/endpoints/bodies.py
+++ b/app/api/api_v1/endpoints/bodies.py
@@ -26,9 +26,9 @@ def list_bodies(
 
     start = (page - 1) * query.limit
 
-    count = crud.body.get_count(db)
-
-    bodies = crud.body.get_multi(db, query_params=query, skip=start, limit=query.limit)
+    bodies, count = crud.body.get_multi(
+        db, query_params=query, skip=start, limit=query.limit
+    )
 
     return PaginatedResponse.paginate(
         request=req,
@@ -59,9 +59,9 @@ def list_bodies_paginated(
     """
     start = (page - 1) * query.limit
 
-    count = crud.body.get_count(db, query_params=query)
-
-    bodies = crud.body.get_multi(db, query_params=query, skip=start, limit=query.limit)
+    bodies, count = crud.body.get_multi(
+        db, query_params=query, skip=start, limit=query.limit
+    )
 
     return PaginatedResponse.paginate(
         request=req,

--- a/app/crud/crud_body.py
+++ b/app/crud/crud_body.py
@@ -1,4 +1,4 @@
-from typing import List, TypeVar
+from typing import List, Tuple, TypeVar
 
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
@@ -56,21 +56,17 @@ class CRUDBody(CRUDBase[Body, BodyCreate, BodyUpdate]):
 
         return query
 
-    def get_count(
-        self,
-        db: Session,
-        query_params: QueryParams,
-    ) -> int:
-        query = db.query(self.model)
-        return self.get_filter_query(query, query_params).count()
 
     def get_multi(
         self, db: Session, *, query_params: QueryParams, skip: int = 0, limit: int = 100
-    ) -> List[ModelType]:
+    ) -> Tuple[List[ModelType], int]:
         query = db.query(self.model)
         # Filter w/Query Params:
         query = self.get_filter_query(query, query_params)
-        return query.offset(skip).limit(limit).all()
+
+        count = query.count()
+
+        return query.offset(skip).limit(limit).all(), count
 
 
 body = CRUDBody(Body)


### PR DESCRIPTION
feat: Improved the get_multi() call to return a Tuple of query, count. This allows us to remove the duplicated db query for the count for this queryset.

Includes removing duplicated count call for bodies endpoint.