### PR TITLE
feat: Added API base RedirectResponse() for "/" => "/api/v1" route.

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     # API version 1 base URL, e.g., "https://perseus.observerly.com/api/v1"
     API_V1_STR: str = "/api/v1"
 
-    API_VERSION: str = "v1.0.0@latest (2022-06-22)"
+    API_VERSION: str = "v1.0.0@latest (2022-06-24)"
 
     SECRET_KEY: str = token_urlsafe(64)
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,13 +4,21 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, RedirectResponse
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.redis import RedisBackend
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from app.api.api_v1.api import api_router
 from app.core.config import settings
+
+API_DESCRIPTION = "\
+Perseus Billion Stars API is observerly's Fast API \
+of stars, galaxies and other astronomical bodies, \
+adhering to the OpenAAS standard.\
+"
+
+API_NAME = "Perseus Billion Stars API by observerly"
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
@@ -55,6 +63,21 @@ if settings.PROJECT_ENVIRONMENT == "production":
     app.add_middleware(SentryAsgiMiddleware)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
+
+@app.get("/")
+async def redirect_index():
+    response = RedirectResponse(url="{0}".format(settings.API_V1_STR))
+    return response
+
+
+@app.get("{0}".format(settings.API_V1_STR))
+async def api_v1_base():
+    return {
+        "description": API_DESCRIPTION,
+        "endpoint": "{0}".format(settings.API_V1_STR),
+        "name": API_NAME,
+    }
 
 
 @app.middleware("http")

--- a/app/tests/api/api_v1/test_base.py
+++ b/app/tests/api/api_v1/test_base.py
@@ -1,0 +1,47 @@
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.main import API_DESCRIPTION
+
+
+@pytest.mark.asyncio
+async def test_base_index_route_returns_http_redirect_status(
+    client: AsyncClient,
+) -> None:
+    response = await client.get(
+        "/",
+        headers={"Host": "perseus.docker.localhost"},
+    )
+
+    assert response.status_code in [301, 302, 307]
+
+
+@pytest.mark.asyncio
+async def test_base_api_v1_route_returns_http_ok_status(
+    client: AsyncClient,
+) -> None:
+    response = await client.get(
+        f"{settings.API_V1_STR}",
+        headers={"Host": "perseus.docker.localhost"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_base_api_v1_route_returns_correct_json_body(
+    client: AsyncClient,
+) -> None:
+    response = await client.get(
+        f"{settings.API_V1_STR}",
+        headers={"Host": "perseus.docker.localhost"},
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["description"] == API_DESCRIPTION
+    assert body["endpoint"] == f"{settings.API_V1_STR}"
+    assert body["name"] == "Perseus Billion Stars API by observerly"


### PR DESCRIPTION
feat: Added API base RedirectResponse() for "/" => "/api/v1" route. 

Includes associated test suite for response redirect definition and expected output.