### PR TITLE
ci: Updated Dockerfile to reference https://install.python-poetry.org for poetry install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/src/app
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
   cd /usr/local/bin && \
   ln -s /opt/poetry/bin/poetry && \
   poetry config virtualenvs.create false


### PR DESCRIPTION
ci: Updated Dockerfile to reference https://install.python-poetry.org for poetry install. 

The previous get-poetry.py and install-poetry.py installers are deprecated. Any installs performed using get-poetry.py should be uninstalled and reinstalled using install.python-poetry.org to ensure in-place upgrades are possible.