### PR TITLE
feat: Added ability to query { messier, ngc, ic } column of Body with a sub-string matching to the catalogue.

### DIFF
--- a/app/api/api_v1/params/bodies.py
+++ b/app/api/api_v1/params/bodies.py
@@ -68,3 +68,9 @@ class BodyQueryParams(BaseModel):
         title="The end date / datetime to perform body object search",
         deprecated=True,
     )
+
+    catalogue: Optional[str] = Query(
+        default=None,
+        title="The catalogue of the body object to search",
+        deprecated=True,
+    )

--- a/app/crud/crud_body.py
+++ b/app/crud/crud_body.py
@@ -33,6 +33,8 @@ class CRUDBody(CRUDBase[Body, BodyCreate, BodyUpdate]):
 
         query = self.perform_constellation_search_filter(query, query_params)
 
+        query = self.perform_catalogue_search_filter(query, query_params)
+
         query = self.perform_horizontal_altitude_search_filter(query, query_params)
 
         return query
@@ -137,6 +139,38 @@ class CRUDBody(CRUDBase[Body, BodyCreate, BodyUpdate]):
                     self.model.constellation.op("LIKE")("%{0}%".format(constellation)),
                     self.model.constellation.op("%")("%{0}%".format(constellation)),
                 )
+            )
+
+        return query
+
+    def perform_catalogue_search_filter(
+        self, query: Query, query_params: QueryParams
+    ) -> Query:
+        # Catalogue
+        catalogue = getattr(query_params, "catalogue", None)
+
+        # If no catalogue is specified, return all:
+        if not catalogue or catalogue == "all":
+            return query
+
+        # Otherwise, filter by the given catalogue:
+
+        # Messier:
+        if catalogue.strip().lower() == "messier":
+            query = query.filter(
+                self.model.messier.isnot(None),
+            )
+
+        # New General Catalogue:
+        if catalogue.strip().lower() == "ngc":
+            query = query.filter(
+                self.model.ngc.isnot(None),
+            )
+
+        # Index Catalogue:
+        if catalogue.strip().lower() == "ic":
+            query = query.filter(
+                self.model.ic.isnot(None),
             )
 
         return query

--- a/app/tests/api/api_v1/test_bodies.py
+++ b/app/tests/api/api_v1/test_bodies.py
@@ -250,6 +250,30 @@ async def test_list_bodies_within_the_partial_constellation_ori(
 
 
 @pytest.mark.asyncio
+async def test_list_bodies_within_a_specific_catalogue(client: AsyncClient) -> None:
+    page = 1
+
+    response = await client.get(
+        f"{settings.API_V1_STR}/bodies/{page}?catalogue=Messier",
+        headers={"Host": "perseus.docker.localhost"},
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["count"] == 110
+
+    assert (
+        "https://perseus.docker.localhost/api/v1/bodies/2?limit=20&catalogue=Messier"
+        in body["next_page"]
+    )
+
+    assert body["previous_page"] is None
+    assert len(body["results"]) == 20
+
+
+@pytest.mark.asyncio
 async def test_list_bodies_above_local_observers_horizon(client: AsyncClient) -> None:
     page = 1
 


### PR DESCRIPTION
feat: Added ability to query { messier, ngc, ic } column of Body with a sub-string matching to the catalogue. 

Includes associated additions to test suite for module export definition and expected output.